### PR TITLE
Add AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: "{build}"
+
+platform: x64
+
+branches:
+    only:
+      - master
+
+clone_depth: 10
+
+skip_tags: true
+
+environment:
+  APM_TEST_PACKAGES:
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+install:
+  - ps: Install-Product node 5
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+test: off
+deploy: off

--- a/spec/image-factory-spec.coffee
+++ b/spec/image-factory-spec.coffee
@@ -66,7 +66,7 @@ describe 'Image factory', ->
         imageFactory.writeImage(imagePath, buffer).catch (r) -> error = r
 
       runs ->
-        expect(error.errno).toBe -21
+        expect(error.errno).toBeLessThan 0
         expect(error.code).toBe 'EISDIR'
         expect(error.syscall).toBe 'open'
 


### PR DESCRIPTION
Add configuration file for [AppVeyor](https://ci.appveyor.com/projects)

It's a free CI tool dedicate to Windows.

Travis CI build for Linux and OSX.

You must activate the build on [AppVeyor](https://ci.appveyor.com/projects)

Before go on [badges page](https://ci.appveyor.com/project/bwklein/asciidoc-image-helper/settings/badges) copy the 'Sample markdown code' into the `readme.md` file.